### PR TITLE
Update arrow icon rotation style

### DIFF
--- a/src/components/icons/Arrow.jsx
+++ b/src/components/icons/Arrow.jsx
@@ -9,7 +9,7 @@ function Arrow({ color = 'currentColor', stroke = 'currentColor',
       fill={color}
       stroke={stroke}
       strokeWidth={strokeWidth}
-      style={{ transform: flip ? 'rotate(180deg' : 'none' }}
+      style={{ transform: flip ? 'rotate(180deg)' : 'none' }}
     >
       <path d="M20 15h-8v3.586a1 1 0 0 1 -1.707 .707l-6.586 -6.586a1 1 0 0 1 0 -1.414l6.586 -6.586a1 1 0 0 1 1.707 .707v3.586h8a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1z" />
     </svg>


### PR DESCRIPTION
## Summary
- fix `Arrow` icon rotation style property

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*